### PR TITLE
Adding delegate method for when empty data set view appears/disappears

### DIFF
--- a/Source/UIScrollView+EmptyDataSet.h
+++ b/Source/UIScrollView+EmptyDataSet.h
@@ -176,4 +176,18 @@
  */
 - (void)emptyDataSetDidTapButton:(UIScrollView *)scrollView;
 
+/**
+ Tells the delegate that the empty data set will appear.
+
+ @param scrollView A scrollView subclass informing the delegate.
+ */
+- (void)emptyDataSetWillAppear:(UIScrollView *)scrollView;
+
+/**
+ Tells the delegate that the empty data set will disappear.
+
+ @param scrollView A scrollView subclass informing the delegate.
+ */
+- (void)emptyDataSetWillDisappear:(UIScrollView *)scrollView;
+
 @end

--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -620,6 +620,10 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
         
         // Moves all its subviews
         [view removeSubviews];
+
+        if ([self.emptyDataSetDelegate respondsToSelector:@selector(emptyDataSetWillAppear:)]) {
+            [self.emptyDataSetDelegate emptyDataSetWillAppear:self];
+        }
         
         // If a non-nil custom view is available, let's configure it instead
         if (customView) {
@@ -662,6 +666,10 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
 
 - (void)dzn_invalidate
 {
+    if ([self.emptyDataSetDelegate respondsToSelector:@selector(emptyDataSetWillDisappear:)]) {
+        [self.emptyDataSetDelegate emptyDataSetWillDisappear:self];
+    }
+
     if (self.emptyDataSetView) {
         [self.emptyDataSetView removeSubviews];
         [self.emptyDataSetView removeFromSuperview];


### PR DESCRIPTION
Currently there is no way to hide the tableHeaderView or tableFooterView. I have added in 2 delegate methods that will notify the view when the the empty data set is going to appear or disappear.
