### PR TITLE
The isEmptyDataSetVisible property was not being tracked correctly by API

### DIFF
--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -372,7 +372,12 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
 - (BOOL)isEmptyDataSetVisible
 {
     UIView *view = objc_getAssociatedObject(self, kEmptyDataSetView);
-    return !view.hidden;
+    if (view) {
+        return !view.hidden;
+    }
+    else {
+        return NO;
+    }
 }
 
 - (BOOL)dzn_canDisplay
@@ -715,13 +720,13 @@ void dzn_original_implementation(id self, SEL _cmd)
     
     IMP impPointer = [impValue pointerValue];
     
+    // We then inject the additional implementation for reloading the empty dataset
+    [self dzn_reloadEmptyDataSet];
+
     // If found, call original implementation
     if (impPointer) {
         ((void(*)(id,SEL))impPointer)(self,_cmd);
     }
-    
-    // We then inject the additional implementation for reloading the empty dataset
-    [self dzn_reloadEmptyDataSet];
 }
 
 NSString *dzn_implementationKey(id target, SEL selector)


### PR DESCRIPTION
The isEmptyDataSetVisible property was not being tracked correctly by API users because it was being set AFTER the UITableView's reloadData method was being executed, therefore the isEmptyDataSetVisible was outdated. 

Changing the order in the swizzle calls did fix it.

Also, the isEmptyDataSetVisible getter was working incorrectly when the view == nil
