### PR TITLE
Change autoresizingMask to only scale width and height.

### DIFF
--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -68,7 +68,7 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
     if (!view)
     {
         view = [DZNEmptyDataSetView new];
-        view.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight|UIViewAutoresizingFlexibleTopMargin|UIViewAutoresizingFlexibleBottomMargin;
+        view.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
         view.userInteractionEnabled = YES;
         view.hidden = YES;
         


### PR DESCRIPTION
This fixes an issue I'm having in a viewcontroller that contains 2 `UITableView`s.

These `UITableView`s are added to the main view, and sized using AutoLayout.

In my `viewWillAppear`, I load some data over the network which can be cached in a `NSURLCache`.

When this data is loaded from the `NSURLCache`, it will reload the `UITableView`s _before_ `viewDidAppear`.

At this point, AutoLayout has not resized my `UITableView`s yet, and they have a size of `CGRectZero`. If the `DZNEmptyDataSetView` is added to the `UITableView` at this point, its `resizingMask` will cause it to have a height that's exactly equal to 1/3rd of the `UITableView`'s height.

This _looks_ okay, because `DZNEmptyDataSetView` doesn't `clipToBounds`, but when you try to tap the `UIButton`, it will be rendered outside the `DZNEmptyDataSetView` and thus not respond to touches.

This pullrequest changes the `DZNEmptyDataSetView` to _not_ have flexible top and bottom margins, which fixes this issue for me.
