### PR TITLE
Always send EmptyDataSet view to back

### DIFF
--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -363,7 +363,7 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
         if (!view.superview) {
 
             // Send the view to back, in case a header and/or footer is present
-            if ([self isKindOfClass:[UITableView class]] && self.subviews.count > 1) {
+            if (self.subviews.count > 1) {
                 [self insertSubview:view atIndex:1];
             }
             else {


### PR DESCRIPTION
This supports collection views or scroll views implementing their own static non-scrolling content, like our app.

I found when this was changed but am unsure of the intent: https://github.com/dzenbot/DZNEmptyDataSet/commit/4e376e42fca8cd82a88877af26624d8474240418

If this looks good as-is then the PR is ready to go, otherwise know that I am having an issue where without this change my collectionview's static header is getting covered over. I imagine anyone with custom static non-scrolling content using this library will have the same problem.