### PR TITLE
Fix crash when implementing gesturerecognizerdelegate

### DIFF
--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -563,7 +563,7 @@ NSString *dzn_implementationKey(id target, SEL selector)
     else{
         // if it is then check if user has his own implementation of silmutaneous gestures
         if ([self.emptyDataSetDelegate respondsToSelector:@selector(gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:)]) {
-            return [[self.emptyDataSetDelegate performSelector:@selector(gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:) withObject:gestureRecognizer withObject:otherGestureRecognizer] boolValue];
+            return [(id)self.emptyDataSetDelegate gestureRecognizer:gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:otherGestureRecognizer];
         }
         else {
             return NO;

--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -556,19 +556,12 @@ NSString *dzn_implementationKey(id target, SEL selector)
         return YES;
     }
 
-    // check if the delegate is implemented
-    if (self.emptyDataSetDelegate == nil) {
-        return NO;
+    // defer to emptyDataSetDelegate's implementation if available
+    if ([self.emptyDataSetDelegate respondsToSelector:@selector(gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:)]) {
+        return [(id)self.emptyDataSetDelegate gestureRecognizer:gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:otherGestureRecognizer];
     }
-    else{
-        // if it is then check if user has his own implementation of silmutaneous gestures
-        if ([self.emptyDataSetDelegate respondsToSelector:@selector(gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:)]) {
-            return [(id)self.emptyDataSetDelegate gestureRecognizer:gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:otherGestureRecognizer];
-        }
-        else {
-            return NO;
-        }
-    }
+    
+    return NO;
 }
 
 


### PR DESCRIPTION
Fix bug that crashes app when implementing gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:

This fixes a crash that occurs when invoking `gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:` on the `emptyDataSetDelegate` and then trying to invoke `boolValue` on the returnvalue.

Since the returnvalue is a BOOL, invoking a method on it causes a `EXC_BAD_ACCESS` crash.

The applied fix does the following:

1. as before, check if the `emptyDataSetDelegate` responds to  `gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:`
1. if it does, cast `emptyDataSetDelegate` to `(id)` and just go ahead  and invoke the method directly instead of using `performSelector`.