### PR TITLE
Fix an issue that causes gestures not reaching the emptyDataSetView on iOS 7

### DIFF
--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -362,14 +362,7 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
         UIView *customView = [self dzn_customView];
         
         if (!view.superview) {
-
-            // Send the view to back, in case a header and/or footer is present
-            if ([self isKindOfClass:[UITableView class]] && self.subviews.count > 1) {
-                [self insertSubview:view atIndex:1];
-            }
-            else {
-                [self addSubview:view];
-            }
+            [self insertSubview:view atIndex:[self indexForEmptyDataSetView]];
         }
         
         // Moves all its subviews
@@ -393,7 +386,7 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
             [view.button setBackgroundImage:[self dzn_buttonBackgroundImageForState:0] forState:0];
             [view.button setBackgroundImage:[self dzn_buttonBackgroundImageForState:1] forState:1];
             [view.button setUserInteractionEnabled:[self dzn_isTouchAllowed]];
-
+            
             // Configure spacing
             view.verticalSpace = [self dzn_verticalSpace];
         }
@@ -413,6 +406,29 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
     }
     else if (self.isEmptyDataSetVisible) {
         [self dzn_invalidate];
+    }
+}
+
+- (NSInteger)indexForEmptyDataSetView {
+    // Send the view to back, in case a header and/or footer is present
+    if ([self isKindOfClass:[UITableView class]] && self.subviews.count > 1) {
+        if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_6_1 &&
+            floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_7_1) {
+            // annoying hack to work around an iOS 7 issue
+            __block NSUInteger *highestIndexOfTableViewFittingSubview = 0;
+            [self.subviews enumerateObjectsUsingBlock:^(UIView *subview, NSUInteger idx, BOOL *stop) {
+                if (CGRectEqualToRect(subview.bounds, self.frame)) {
+                    highestIndexOfTableViewFittingSubview = idx;
+                }
+            }];
+            return highestIndexOfTableViewFittingSubview+1;
+        }
+        else {
+            return 1;
+        }
+    }
+    else {
+        return self.subviews.count;
     }
 }
 


### PR DESCRIPTION
This commit introduces a `indexForEmptyDataSetView` method to encapsulate the logic that figures out where to insert the `DZNEmptyDataSetView` in the `UIScrollView` subviews hierarchy.

Figuring out the proper index is moderately complex because it needs some decision making based on the `UIScrollView`s actual class and the current iOS version.

This is a fix for #47 