### PR TITLE
Fix CFXNotificationPost crash

### DIFF
--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -40,6 +40,10 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
 
 @implementation UIScrollView (DZNEmptyDataSet)
 
+-(void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
 #pragma mark - Getters (Public)
 
 - (id<DZNEmptyDataSetSource>)emptyDataSetSource


### PR DESCRIPTION
When deallocated the observers was still assign as NSNotificationCenter observers.
This was causing a crash when deviceDidChangeOrientation occurs
