### PR TITLE
add empty dataset userInteractionEnabled delegate support

### DIFF
--- a/Source/UIScrollView+EmptyDataSet.h
+++ b/Source/UIScrollView+EmptyDataSet.h
@@ -167,14 +167,6 @@
 - (BOOL)emptyDataSetShouldAllowScroll:(UIScrollView *)scrollView;
 
 /**
- Asks the delegate for empty dataset userInteraction permission. Default is YES.
- 
- @param scrollView A scrollView subclass object informing the delegate.
- @return YES if the empty dataset  userInteraction is enabled.
- */
-- (BOOL)emptyDataSetShouldEnableUserInteraction:(UIScrollView *)scrollView;
-
-/**
  Tells the delegate that the empty dataset view was tapped.
  Use this method either to resignFirstResponder of a textfield or searchBar.
  

--- a/Source/UIScrollView+EmptyDataSet.h
+++ b/Source/UIScrollView+EmptyDataSet.h
@@ -167,6 +167,14 @@
 - (BOOL)emptyDataSetShouldAllowScroll:(UIScrollView *)scrollView;
 
 /**
+ Asks the delegate for empty dataset userInteraction permission. Default is YES.
+ 
+ @param scrollView A scrollView subclass object informing the delegate.
+ @return YES if the empty dataset  userInteraction is enabled.
+ */
+- (BOOL)emptyDataSetShouldEnableUserInteraction:(UIScrollView *)scrollView;
+
+/**
  Tells the delegate that the empty dataset view was tapped.
  Use this method either to resignFirstResponder of a textfield or searchBar.
  

--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -272,14 +272,6 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
     return NO;
 }
 
-- (BOOL)dzn_isUserInteractionEnabled
-{
-    if (self.emptyDataSetDelegate && [self.emptyDataSetDelegate respondsToSelector:@selector(emptyDataSetShouldEnableUserInteraction:)]) {
-        return [self.emptyDataSetDelegate emptyDataSetShouldEnableUserInteraction:self];
-    }
-    return YES;
-}
-
 - (void)dzn_willWillAppear
 {
     if (self.emptyDataSetDelegate && [self.emptyDataSetDelegate respondsToSelector:@selector(emptyDataSetWillAppear:)]) {
@@ -414,7 +406,6 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
             [view.button setAttributedTitle:[self dzn_buttonTitleForState:UIControlStateHighlighted] forState:UIControlStateHighlighted];
             [view.button setBackgroundImage:[self dzn_buttonBackgroundImageForState:UIControlStateNormal] forState:UIControlStateNormal];
             [view.button setBackgroundImage:[self dzn_buttonBackgroundImageForState:UIControlStateHighlighted] forState:UIControlStateHighlighted];
-            [view.button setUserInteractionEnabled:[self dzn_isTouchAllowed]];
 
             // Configure spacing
             view.verticalSpace = [self dzn_verticalSpace];
@@ -434,7 +425,7 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
         self.scrollEnabled = [self dzn_isScrollAllowed];
 
         // Confiruge empty dataset userInteraction permission
-        view.userInteractionEnabled = [self dzn_isUserInteractionEnabled];
+        view.userInteractionEnabled = [self dzn_isTouchAllowed];
     }
     else if (self.isEmptyDataSetVisible) {
         [self dzn_invalidate];

--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -69,7 +69,6 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
     {
         view = [DZNEmptyDataSetView new];
         view.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
-        view.userInteractionEnabled = YES;
         view.hidden = YES;
         
         view.tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dzn_didTapContentView:)];
@@ -273,6 +272,14 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
     return NO;
 }
 
+- (BOOL)dzn_isUserInteractionEnabled
+{
+    if (self.emptyDataSetDelegate && [self.emptyDataSetDelegate respondsToSelector:@selector(emptyDataSetShouldEnableUserInteraction:)]) {
+        return [self.emptyDataSetDelegate emptyDataSetShouldEnableUserInteraction:self];
+    }
+    return YES;
+}
+
 - (void)dzn_willWillAppear
 {
     if (self.emptyDataSetDelegate && [self.emptyDataSetDelegate respondsToSelector:@selector(emptyDataSetWillAppear:)]) {
@@ -425,6 +432,9 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
         
         // Configure scroll permission
         self.scrollEnabled = [self dzn_isScrollAllowed];
+
+        // Confiruge empty dataset userInteraction permission
+        view.userInteractionEnabled = [self dzn_isUserInteractionEnabled];
     }
     else if (self.isEmptyDataSetVisible) {
         [self dzn_invalidate];


### PR DESCRIPTION
Hi,

I recently add the empty dataset to my collection view, and my collection view has a header to show some informations, buttons and so on. When the empty dataset show, I don't want it cover my collection view header, so I use offset, but the empty dataset view is actually covered the whole collection view. And the userInteractionEnabled for empty dataset is `true`, so any interaction occurred in collection view header would be prevent, so I have to disable the userInteraction in empty dataset view, but there is no such view exported or delegate to use, so I added this delegate. I'd like to have some your options about this situation. Thank you very much!

Yours, Hao