### PR TITLE
Fix header & footer interaction on UICollectionView

### DIFF
--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -373,7 +373,7 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
         if (!view.superview) {
 
             // Send the view to back, in case a header and/or footer is present
-            if ([self isKindOfClass:[UITableView class]] && self.subviews.count > 1) {
+            if (([self isKindOfClass:[UITableView class]] || [self isKindOfClass:[UICollectionView class]]) && self.subviews.count > 1) {
                 [self insertSubview:view atIndex:1];
             }
             else {


### PR DESCRIPTION
On `UICollectionView`, the empty view was being rendered on top of the header, so I could't interact with the header. This fixes it.