### PR TITLE
Add emptyDataSetDidAppear method

### DIFF
--- a/Source/UIScrollView+EmptyDataSet.h
+++ b/Source/UIScrollView+EmptyDataSet.h
@@ -189,6 +189,13 @@
 - (void)emptyDataSetWillAppear:(UIScrollView *)scrollView;
 
 /**
+ Tells the delegate that the empty data set did appear.
+
+ @param scrollView A scrollView subclass informing the delegate.
+ */
+- (void)emptyDataSetDidAppear:(UIScrollView *)scrollView;
+
+/**
  Tells the delegate that the empty data set will disappear.
 
  @param scrollView A scrollView subclass informing the delegate.

--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -279,6 +279,13 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
     }
 }
 
+- (void)dzn_didAppear
+{
+    if (self.emptyDataSetDelegate && [self.emptyDataSetDelegate respondsToSelector:@selector(emptyDataSetDidAppear:)]) {
+        [self.emptyDataSetDelegate emptyDataSetDidAppear:self];
+    }
+}
+
 - (void)dzn_willDisappear
 {
     if (self.emptyDataSetDelegate && [self.emptyDataSetDelegate respondsToSelector:@selector(emptyDataSetWillDisappear:)]) {
@@ -426,6 +433,9 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
 
         // Confiruge empty dataset userInteraction permission
         view.userInteractionEnabled = [self dzn_isTouchAllowed];
+
+        // Notifies that the empty dataset view did appear
+        [self dzn_didAppear];
     }
     else if (self.isEmptyDataSetVisible) {
         [self dzn_invalidate];


### PR DESCRIPTION
Notify the delegate when the data set was displayed. The user might want to do further layout customization at this point.

I figure this is a more generic way of allowing the delegate to customize the view, after layout has been applied. What I'm really trying to do, is to align the custom view to the top of the empty view. I'd like the custom view to be offset X points from the top, which isn't possible right now because of [this autolayout line](https://github.com/dzenbot/DZNEmptyDataSet/blob/9dc57d850d2da1b73f90e66a174bac53a3ba12ef/Source/UIScrollView%2BEmptyDataSet.m#L790-L791).

Other ideas for allowing this, are definitely encouraged, and I'm willing to implement it.