### PR TITLE
Fixed doc

### DIFF
--- a/Source/UIScrollView+EmptyDataSet.h
+++ b/Source/UIScrollView+EmptyDataSet.h
@@ -107,7 +107,7 @@
 /**
  Asks the data source for a custom view to be displayed instead of the default views such as labels, imageview and button. Default is nil.
  Use this method to show an activity view indicator for loading feedback, or for complete custom empty data set.
- Returning a custom view will ignore -offsetForEmptyDataSet and -spaceHeightForEmptyDataSet configurations.
+ Returning a custom view will ignore -spaceHeightForEmptyDataSet configuration.
  
  @param scrollView A scrollView subclass object informing the delegate.
  @return The custom view.


### PR DESCRIPTION
It's clear to me that even if you use a custom view, the offset is still applied, contrary to what the doc suggests:
https://github.com/dzenbot/DZNEmptyDataSet/blob/master/Source/UIScrollView%2BEmptyDataSet.m#L422

Sorry for being picky, it's just a minor outdated doc, I guess.

Currently trying to resolve the collection view header tapping issue.