### PR TITLE
Auto layout simplified: No more dealloc swizzling. Closes #103, closes #104, closes #105, closes #108

### DIFF
--- a/Examples/Applications/Applications/Application.h
+++ b/Examples/Applications/Applications/Application.h
@@ -9,6 +9,9 @@
 #import <Foundation/Foundation.h>
 
 typedef NS_ENUM(NSUInteger, ApplicationType) {
+    
+    ApplicationTypeUndefined = 0,
+    
     ApplicationType500px = 1,
     ApplicationTypeAirbnb,
     ApplicationTypeAppstore,
@@ -37,7 +40,7 @@ typedef NS_ENUM(NSUInteger, ApplicationType) {
     ApplicationTypeWhatsapp,
     ApplicationTypeWWDC,
     
-    ApplicationCount // Used for count
+    ApplicationCount // Used for count (27)
 };
 
 @interface Application : NSObject

--- a/Examples/Applications/Applications/Application.h
+++ b/Examples/Applications/Applications/Application.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 
 typedef NS_ENUM(NSUInteger, ApplicationType) {
-    ApplicationType500px,
+    ApplicationType500px = 1,
     ApplicationTypeAirbnb,
     ApplicationTypeAppstore,
     ApplicationTypeCamera,
@@ -35,7 +35,9 @@ typedef NS_ENUM(NSUInteger, ApplicationType) {
     ApplicationTypeVesper,
     ApplicationTypeVine,
     ApplicationTypeWhatsapp,
-    ApplicationTypeWWDC
+    ApplicationTypeWWDC,
+    
+    ApplicationCount // Used for count
 };
 
 @interface Application : NSObject

--- a/Examples/Applications/Applications/Application.m
+++ b/Examples/Applications/Applications/Application.m
@@ -31,7 +31,7 @@
     
     self.iconName = [[[NSString stringWithFormat:@"icon_%@", self.displayName] lowercaseString] stringByReplacingOccurrencesOfString:@" " withString:@"_"];
     
-    self.type = applicationTypeFromString(self.displayName);
+    self.type = applicationTypeFromString(self.displayName) + 1;
 }
 
 ApplicationType applicationTypeFromString(NSString *string)

--- a/Examples/Applications/Applications/DetailViewController.h
+++ b/Examples/Applications/Applications/DetailViewController.h
@@ -11,6 +11,9 @@
 
 @interface DetailViewController : UITableViewController
 
+@property (nonatomic, weak) NSArray *applications;
+@property (nonatomic) BOOL allowSuffling;
+
 - (instancetype)initWithApplication:(Application *)app;
 
 @end

--- a/Examples/Applications/Applications/DetailViewController.m
+++ b/Examples/Applications/Applications/DetailViewController.m
@@ -410,7 +410,7 @@
         }
         case ApplicationTypeRemote:
         {
-            text = @"Cannot Connect to a\nLocal Network";
+            text = @"Cannot Connect to a Local Network";
             font = [UIFont fontWithName:@"HelveticaNeue-Medium" size:18.0];
             textColor = [UIColor colorWithHex:@"555555"];
             break;
@@ -494,14 +494,14 @@
     switch (self.application.type) {
         case ApplicationType500px:
         {
-            text = @"Get started by uploading a\nphoto.";
+            text = @"Get started by uploading a photo.";
             font = [UIFont boldSystemFontOfSize:15.0];
             textColor = [UIColor colorWithHex:@"545454"];
             break;
         }
         case ApplicationTypeAirbnb:
         {
-            text = @"When you have messages, you’ll\nsee them here.";
+            text = @"When you have messages, you’ll see them here.";
             font = [UIFont systemFontOfSize:13.0];
             textColor = [UIColor colorWithHex:@"cfcfcf"];
             paragraph.lineSpacing = 4.0;
@@ -544,7 +544,7 @@
         }
         case ApplicationTypeiCloud:
         {
-            text = @"Share photos and videos with\njust the people you choose, and let them add photos,\nvideos, and comments.";
+            text = @"Share photos and videos with just the people you choose, and let them add photos, videos, and comments.";
             paragraph.lineSpacing = 2.0;
             break;
         }
@@ -558,13 +558,13 @@
         }
         case ApplicationTypeiTunesConnect:
         {
-            text = @"To add a favorite, tap the star icon next\nto an App's name.";
+            text = @"To add a favorite, tap the star icon next to an App's name.";
             font = [UIFont systemFontOfSize:14.0];
             break;
         }
         case ApplicationTypeKickstarter:
         {
-            text = @"When you back a project or follow a friend,\ntheir activity will show up here.";
+            text = @"When you back a project or follow a friend, their activity will show up here.";
             font = [UIFont systemFontOfSize:14.0];
             textColor = [UIColor colorWithHex:@"828587"];
             break;
@@ -583,7 +583,7 @@
         }
         case ApplicationTypePodcasts:
         {
-            text = @"You can subscribe to podcasts in\nTop Charts or Featured.";
+            text = @"You can subscribe to podcasts in Top Charts or Featured.";
             break;
         }
         case ApplicationTypeRemote:
@@ -602,7 +602,7 @@
         }
         case ApplicationTypeSkype:
         {
-            text = @"Keep all your favorite people\ntogether, add favorites.";
+            text = @"Keep all your favorite people together, add favorites.";
             font = [UIFont fontWithName:@"HelveticaNeue-Light" size:17.75];
             textColor = [UIColor colorWithHex:@"a6c3d1"];
             paragraph.lineSpacing = 3.0;
@@ -610,7 +610,7 @@
         }
         case ApplicationTypeSlack:
         {
-            text = @"You don't have any\nrecent mentions";
+            text = @"You don't have any recent mentions";
             font = [UIFont fontWithName:@"Lato-Regular" size:19.0];
             textColor = [UIColor colorWithHex:@"d7d7d7"];
             break;

--- a/Examples/Applications/Applications/DetailViewController.m
+++ b/Examples/Applications/Applications/DetailViewController.m
@@ -196,6 +196,7 @@
     else {
         self.navigationItem.titleView = nil;
         self.navigationItem.title = self.application.displayName;
+        self.navigationController.navigationBar.titleTextAttributes = nil;
     }
     
     self.navigationController.navigationBar.barTintColor = barColor;
@@ -253,7 +254,7 @@
 {
     Application *randomApp = [self randomApplication];
     
-    while ([randomApp.identifier isEqualToString:self.application.identifier]) {
+    while ([randomApp.identifier isEqualToString:self.application.identifier] || randomApp.type == ApplicationTypeUndefined) {
         randomApp = [self randomApplication];
     }
     

--- a/Examples/Applications/Applications/MainViewController.m
+++ b/Examples/Applications/Applications/MainViewController.m
@@ -222,6 +222,8 @@
 {
     Application *app = [[self filteredApps] objectAtIndex:indexPath.row];
     DetailViewController *controller = [[DetailViewController alloc] initWithApplication:app];
+    controller.applications = self.applications;
+    controller.allowSuffling = YES;
     
     [self.navigationController pushViewController:controller animated:YES];
 }

--- a/Examples/Countries/Countries/MainViewController.m
+++ b/Examples/Countries/Countries/MainViewController.m
@@ -52,7 +52,7 @@
     
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemRefresh target:self action:@selector(reloadContent:)];
     
-    self.loading = NO;
+    self.loading = YES;
     
     [self.view addSubview:self.tableView];
     [self.view addSubview:self.searchBar];

--- a/Source/UIScrollView+EmptyDataSet.h
+++ b/Source/UIScrollView+EmptyDataSet.h
@@ -130,7 +130,8 @@
  @param scrollView A scrollView subclass object informing the delegate.
  @return The offset for vertical and horizontal alignment.
  */
-- (CGPoint)offsetForEmptyDataSet:(UIScrollView *)scrollView;
+- (CGPoint)offsetForEmptyDataSet:(UIScrollView *)scrollView DEPRECATED_MSG_ATTRIBUTE("Use -verticalOffsetForEmptyDataSet:");
+- (CGFloat)verticalOffsetForEmptyDataSet:(UIScrollView *)scrollView;
 
 /**
  Asks the data source for a vertical space between elements. Default is 11 pts.

--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -11,6 +11,13 @@
 #import "UIScrollView+EmptyDataSet.h"
 #import <objc/runtime.h>
 
+@interface UIView (DZNConstraintBasedLayoutExtensions)
+
+- (NSLayoutConstraint *)equallyRelatedConstraintWithView:(UIView *)view attribute:(NSLayoutAttribute)attribute;
+
+@end
+
+
 @interface DZNEmptyDataSetView : UIView
 
 @property (nonatomic, readonly) UIView *contentView;
@@ -21,20 +28,21 @@
 @property (nonatomic, strong) UIView *customView;
 @property (nonatomic, strong) UITapGestureRecognizer *tapGesture;
 
-@property (nonatomic, assign) CGPoint offset;
+@property (nonatomic, assign) CGFloat verticalOffset;
 @property (nonatomic, assign) CGFloat verticalSpace;
 
-- (void)removeAllSubviews;
+- (void)setupConstraints;
+- (void)removeAllConstraints;
+- (void)prepareForReuse;
 
 @end
+
 
 #pragma mark - UIScrollView+EmptyDataSet
 
 static char const * const kEmptyDataSetSource =     "emptyDataSetSource";
 static char const * const kEmptyDataSetDelegate =   "emptyDataSetDelegate";
 static char const * const kEmptyDataSetView =       "emptyDataSetView";
-
-static NSString * const kEmptyDataSetDealloc =      @"dealloc";
 
 @interface UIScrollView () <UIGestureRecognizerDelegate>
 @property (nonatomic, readonly) DZNEmptyDataSetView *emptyDataSetView;
@@ -76,7 +84,7 @@ static NSString * const kEmptyDataSetDealloc =      @"dealloc";
         view.tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dzn_didTapContentView:)];
         view.tapGesture.delegate = self;
         [view addGestureRecognizer:view.tapGesture];
-
+        
         [self setEmptyDataSetView:view];
     }
     return view;
@@ -141,7 +149,7 @@ static NSString * const kEmptyDataSetDealloc =      @"dealloc";
 
 #pragma mark - Data Source Getters
 
-- (NSAttributedString *)dzn_titleLabelText
+- (NSAttributedString *)dzn_titleLabelString
 {
     if (self.emptyDataSetSource && [self.emptyDataSetSource respondsToSelector:@selector(titleForEmptyDataSet:)]) {
         NSAttributedString *string = [self.emptyDataSetSource titleForEmptyDataSet:self];
@@ -151,7 +159,7 @@ static NSString * const kEmptyDataSetDealloc =      @"dealloc";
     return nil;
 }
 
-- (NSAttributedString *)dzn_detailLabelText
+- (NSAttributedString *)dzn_detailLabelString
 {
     if (self.emptyDataSetSource && [self.emptyDataSetSource respondsToSelector:@selector(descriptionForEmptyDataSet:)]) {
         NSAttributedString *string = [self.emptyDataSetSource descriptionForEmptyDataSet:self];
@@ -231,21 +239,13 @@ static NSString * const kEmptyDataSetDealloc =      @"dealloc";
     return nil;
 }
 
-- (CGPoint)dzn_offset
+- (CGFloat)dzn_verticalOffset
 {
-    CGFloat top = roundf(self.contentInset.top / 2.0);
-    CGFloat left = roundf(self.contentInset.left / 2.0);
-    CGFloat bottom = roundf(self.contentInset.bottom / 2.0);
-    CGFloat right = roundf(self.contentInset.right / 2.0);
+    CGFloat offset = 0.0;
     
-    // Honors the scrollView's contentInset
-    CGPoint offset = CGPointMake(left-right, top-bottom);
-    
-    if (self.emptyDataSetSource && [self.emptyDataSetSource respondsToSelector:@selector(offsetForEmptyDataSet:)]) {
-        CGPoint customOffset = [self.emptyDataSetSource offsetForEmptyDataSet:self];
-        offset = CGPointMake(offset.x + customOffset.x, offset.y + customOffset.y);
+    if (self.emptyDataSetSource && [self.emptyDataSetSource respondsToSelector:@selector(verticalOffsetForEmptyDataSet:)]) {
+        offset = [self.emptyDataSetSource verticalOffsetForEmptyDataSet:self];
     }
-    
     return offset;
 }
 
@@ -329,40 +329,30 @@ static NSString * const kEmptyDataSetDealloc =      @"dealloc";
 
 #pragma mark - Setters (Public)
 
-- (void)setEmptyDataSetSource:(id<DZNEmptyDataSetSource>)source
+- (void)setEmptyDataSetSource:(id<DZNEmptyDataSetSource>)datasource
 {
-    // Registers for device orientation changes
-    if (source && !self.emptyDataSetSource) {
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(dzn_deviceDidChangeOrientation:) name:UIDeviceOrientationDidChangeNotification object:nil];
-        [self swizzle:NSSelectorFromString(kEmptyDataSetDealloc)];
-    }
-    // Skip if the datasource is already set up
-    else {
-        return;
+    if (!datasource || ![self dzn_canDisplay]) {
+        [self dzn_invalidate];
     }
     
-    objc_setAssociatedObject(self, kEmptyDataSetSource, source, OBJC_ASSOCIATION_ASSIGN);
-    
-    if (![self dzn_canDisplay]) {
-        return;
-    }
+    objc_setAssociatedObject(self, kEmptyDataSetSource, datasource, OBJC_ASSOCIATION_ASSIGN);
     
     // We add method sizzling for injecting -dzn_reloadData implementation to the native -reloadData implementation
-    [self swizzle:@selector(reloadData)];
+    [self swizzleIfPossible:@selector(reloadData)];
     
     // Exclusively for UITableView, we also inject -dzn_reloadData to -endUpdates
     if ([self isKindOfClass:[UITableView class]]) {
-        [self swizzle:@selector(endUpdates)];
+        [self swizzleIfPossible:@selector(endUpdates)];
     }
 }
 
 - (void)setEmptyDataSetDelegate:(id<DZNEmptyDataSetDelegate>)delegate
 {
-    objc_setAssociatedObject(self, kEmptyDataSetDelegate, delegate, OBJC_ASSOCIATION_ASSIGN);
-    
     if (!delegate) {
         [self dzn_invalidate];
     }
+    
+    objc_setAssociatedObject(self, kEmptyDataSetDelegate, delegate, OBJC_ASSOCIATION_ASSIGN);
 }
 
 
@@ -396,10 +386,9 @@ static NSString * const kEmptyDataSetDealloc =      @"dealloc";
         [self dzn_willAppear];
         
         DZNEmptyDataSetView *view = self.emptyDataSetView;
-        UIView *customView = [self dzn_customView];
         
         if (!view.superview) {
-
+            
             // Send the view to back, in case a header and/or footer is present
             if (([self isKindOfClass:[UITableView class]] || [self isKindOfClass:[UICollectionView class]]) && self.subviews.count > 1) {
                 [self insertSubview:view atIndex:1];
@@ -409,30 +398,46 @@ static NSString * const kEmptyDataSetDealloc =      @"dealloc";
             }
         }
         
-        // Moves all its subviews
-        [view removeAllSubviews];
+        // Moves all its subviews and constraints
+        [view prepareForReuse];
+        
+        UIView *customView = [self dzn_customView];
         
         // If a non-nil custom view is available, let's configure it instead
         if (customView) {
             view.customView = customView;
         }
         else {
-            // Configure labels
-            view.detailLabel.attributedText = [self dzn_detailLabelText];
-            view.titleLabel.attributedText = [self dzn_titleLabelText];
+            // Get the data from the data source
+            NSAttributedString *titleLabelString = [self dzn_titleLabelString];
+            NSAttributedString *detailLabelString = [self dzn_detailLabelString];
             
-            // Configure imageview
-            UIColor *tintColor = [self dzn_imageTintColor];
-            UIImage *image = [self dzn_image];
-            UIImageRenderingMode renderingMode = tintColor ? UIImageRenderingModeAlwaysTemplate : UIImageRenderingModeAlwaysOriginal;
-            
-            view.imageView.image = [image imageWithRenderingMode:renderingMode];
-            view.imageView.tintColor = tintColor;
-            
-            // Configure button
             UIImage *buttonImage = [self dzn_buttonImageForState:UIControlStateNormal];
             NSAttributedString *buttonTitle = [self dzn_buttonTitleForState:UIControlStateNormal];
-
+            
+            UIImage *image = [self dzn_image];
+            UIColor *imageTintColor = [self dzn_imageTintColor];
+            UIImageRenderingMode renderingMode = imageTintColor ? UIImageRenderingModeAlwaysTemplate : UIImageRenderingModeAlwaysOriginal;
+            
+            view.verticalSpace = [self dzn_verticalSpace];
+            
+            // Configure Image
+            if (image) {
+                view.imageView.image = [image imageWithRenderingMode:renderingMode];
+                view.imageView.tintColor = imageTintColor;
+            }
+            
+            // Configure title label
+            if (titleLabelString) {
+                view.titleLabel.attributedText = titleLabelString;
+            }
+            
+            // Configure detail label
+            if (detailLabelString) {
+                view.detailLabel.attributedText = detailLabelString;
+            }
+            
+            // Configure button
             if (buttonImage) {
                 [view.button setImage:buttonImage forState:UIControlStateNormal];
                 [view.button setImage:[self dzn_buttonImageForState:UIControlStateHighlighted] forState:UIControlStateHighlighted];
@@ -443,27 +448,25 @@ static NSString * const kEmptyDataSetDealloc =      @"dealloc";
                 [view.button setBackgroundImage:[self dzn_buttonBackgroundImageForState:UIControlStateNormal] forState:UIControlStateNormal];
                 [view.button setBackgroundImage:[self dzn_buttonBackgroundImageForState:UIControlStateHighlighted] forState:UIControlStateHighlighted];
             }
-
-            // Configure spacing
-            view.verticalSpace = [self dzn_verticalSpace];
         }
         
-        // Configure Offset
-        view.offset = [self dzn_offset];
+        // Configure offset
+        view.verticalOffset = [self dzn_verticalOffset];
         
         // Configure the empty dataset view
         view.backgroundColor = [self dzn_dataSetBackgroundColor];
         view.hidden = NO;
+        view.clipsToBounds = YES;
         
-        [view updateConstraints];
+        // Configure empty dataset userInteraction permission
+        view.userInteractionEnabled = [self dzn_isTouchAllowed];
+        
+        [view setupConstraints];
         [view layoutIfNeeded];
         
         // Configure scroll permission
         self.scrollEnabled = [self dzn_isScrollAllowed];
-
-        // Configure empty dataset userInteraction permission
-        view.userInteractionEnabled = [self dzn_isTouchAllowed];
-
+        
         // Notifies that the empty dataset view did appear
         [self dzn_didAppear];
     }
@@ -476,38 +479,18 @@ static NSString * const kEmptyDataSetDealloc =      @"dealloc";
 {
     // Notifies that the empty dataset view will disappear
     [self dzn_willDisappear];
-
+    
     if (self.emptyDataSetView) {
-        [self.emptyDataSetView removeAllSubviews];
+        [self.emptyDataSetView prepareForReuse];
         [self.emptyDataSetView removeFromSuperview];
         
         [self setEmptyDataSetView:nil];
     }
     
     self.scrollEnabled = YES;
-
+    
     // Notifies that the empty dataset view did disappear
     [self dzn_didDisappear];
-}
-
-
-#pragma mark - Lifeterm Methods (Private)
-
-- (void)dzn_dealloc
-{
-    // Remove observers
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:UIDeviceOrientationDidChangeNotification object:nil];
-}
-
-
-#pragma mark - Notification Events
-
-- (void)dzn_deviceDidChangeOrientation:(NSNotification *)notification
-{
-    if (self.isEmptyDataSetVisible) {
-        [self.emptyDataSetView updateConstraints];
-        [self.emptyDataSetView layoutIfNeeded];
-    }
 }
 
 
@@ -531,19 +514,13 @@ void dzn_original_implementation(id self, SEL _cmd)
     
     IMP impPointer = [impValue pointerValue];
     
-    // Prevent doing any logic over self during dealloc process
-    if ([key rangeOfString:kEmptyDataSetDealloc].location != NSNotFound) {
-        [self dzn_dealloc];
-    }
-    else {
-        // We then inject the additional implementation for reloading the empty dataset
-        // Doing it before calling the original implementation does update the 'isEmptyDataSetVisible' flag on time.
-        [self dzn_reloadEmptyDataSet];
-        
-        // If found, call original implementation
-        if (impPointer) {
-            ((void(*)(id,SEL))impPointer)(self,_cmd);
-        }
+    // We then inject the additional implementation for reloading the empty dataset
+    // Doing it before calling the original implementation does update the 'isEmptyDataSetVisible' flag on time.
+    [self dzn_reloadEmptyDataSet];
+    
+    // If found, call original implementation
+    if (impPointer) {
+        ((void(*)(id,SEL))impPointer)(self,_cmd);
     }
 }
 
@@ -565,7 +542,7 @@ NSString *dzn_implementationKey(id target, SEL selector)
     return [NSString stringWithFormat:@"%@_%@",className,selectorName];
 }
 
-- (void)swizzle:(SEL)selector
+- (void)swizzleIfPossible:(SEL)selector
 {
     // Check if the target responds to selector
     if (![self respondsToSelector:selector]) {
@@ -624,11 +601,11 @@ NSString *dzn_implementationKey(id target, SEL selector)
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
     UIGestureRecognizer *tapGesture = self.emptyDataSetView.tapGesture;
-
+    
     if ([gestureRecognizer isEqual:tapGesture] || [otherGestureRecognizer isEqual:tapGesture]) {
         return YES;
     }
-
+    
     // defer to emptyDataSetDelegate's implementation if available
     if ( (self.emptyDataSetDelegate != (id)self) && [self.emptyDataSetDelegate respondsToSelector:@selector(gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:)]) {
         return [(id)self.emptyDataSetDelegate gestureRecognizer:gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:otherGestureRecognizer];
@@ -695,7 +672,7 @@ NSString *dzn_implementationKey(id target, SEL selector)
         _imageView.contentMode = UIViewContentModeScaleAspectFit;
         _imageView.userInteractionEnabled = NO;
         _imageView.accessibilityLabel = @"empty set background image";
-
+        
         [_contentView addSubview:_imageView];
     }
     return _imageView;
@@ -751,7 +728,7 @@ NSString *dzn_implementationKey(id target, SEL selector)
         _button.contentHorizontalAlignment = UIControlContentHorizontalAlignmentCenter;
         _button.contentVerticalAlignment = UIControlContentVerticalAlignmentCenter;
         _button.accessibilityLabel = @"empty set button";
-
+        
         [_button addTarget:self action:@selector(didTapButton:) forControlEvents:UIControlEventTouchUpInside];
         
         [_contentView addSubview:_button];
@@ -759,19 +736,23 @@ NSString *dzn_implementationKey(id target, SEL selector)
     return _button;
 }
 
-- (BOOL)canShowImage {
+- (BOOL)canShowImage
+{
     return (_imageView.image && _imageView.superview);
 }
 
-- (BOOL)canShowTitle {
+- (BOOL)canShowTitle
+{
     return (_titleLabel.attributedText.string.length > 0 && _titleLabel.superview);
 }
 
-- (BOOL)canShowDetail {
+- (BOOL)canShowDetail
+{
     return (_detailLabel.attributedText.string.length > 0 && _detailLabel.superview);
 }
 
-- (BOOL)canShowButton {
+- (BOOL)canShowButton
+{
     if ([_button attributedTitleForState:UIControlStateNormal].string.length > 0 || [_button imageForState:UIControlStateNormal]) {
         return (_button.superview != nil) ? YES : NO;
     }
@@ -793,7 +774,7 @@ NSString *dzn_implementationKey(id target, SEL selector)
     }
     
     _customView = view;
-    _customView.translatesAutoresizingMaskIntoConstraints = !CGRectIsEmpty(view.frame);
+    _customView.translatesAutoresizingMaskIntoConstraints = NO;
     [self.contentView addSubview:_customView];
 }
 
@@ -809,7 +790,13 @@ NSString *dzn_implementationKey(id target, SEL selector)
     }
 }
 
-- (void)removeAllSubviews
+- (void)removeAllConstraints
+{
+    [self removeConstraints:self.constraints];
+    [_contentView removeConstraints:_contentView.constraints];
+}
+
+- (void)prepareForReuse
 {
     [self.contentView.subviews makeObjectsPerformSelector:@selector(removeFromSuperview)];
     
@@ -820,128 +807,131 @@ NSString *dzn_implementationKey(id target, SEL selector)
     _customView = nil;
 }
 
-- (void)removeAllConstraints
+
+#pragma mark - Auto-Layout Configuration
+
+- (void)setupConstraints
 {
-    [self removeConstraints:self.constraints];
-    [_contentView removeConstraints:_contentView.constraints];
-}
-
-
-#pragma mark - UIView Constraints & Layout Methods
-
-- (void)updateConstraintsIfNeeded
-{
-    [super updateConstraintsIfNeeded];
-}
-
-- (void)updateConstraints
-{
-    // Cleans up any constraints
-    [self removeAllConstraints];
+    // First, configure the content view constaints
+    // The content view must alway be centered to its superview
+    NSLayoutConstraint *centerXConstraint = [self equallyRelatedConstraintWithView:self.contentView attribute:NSLayoutAttributeCenterX];
+    NSLayoutConstraint *centerYConstraint = [self equallyRelatedConstraintWithView:self.contentView attribute:NSLayoutAttributeCenterY];
     
-    NSMutableDictionary *views = [NSMutableDictionary dictionary];
+    [self addConstraint:centerXConstraint];
+    [self addConstraint:centerYConstraint];
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[contentView]|" options:0 metrics:nil views:@{@"contentView": self.contentView}]];
     
-    [views setObject:self forKey:@"self"];
-    [views setObject:self.contentView forKey:@"contentView"];
-    
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:[self]-(<=0)-[contentView]"
-                                                                 options:NSLayoutFormatAlignAllCenterY metrics:nil views:views]];
-    
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[self]-(<=0)-[contentView]"
-                                                                 options:NSLayoutFormatAlignAllCenterX metrics:nil views:views]];
-    
-    // If a custom offset is available, we modify the contentView's constraints constants
-    if (!CGPointEqualToPoint(self.offset, CGPointZero) && self.constraints.count == 4) {
-        NSLayoutConstraint *vConstraint = self.constraints[1];
-        NSLayoutConstraint *hConstraint = [self.constraints lastObject];
-        
-        // the values must be inverted to follow the up-bottom and left-right directions
-        vConstraint.constant = self.offset.y*-1;
-        hConstraint.constant = self.offset.x*-1;
+    // When a custom offset is available, we adjust the vertical constraints' constants
+    if (self.verticalOffset != 0 && self.constraints.count > 0) {
+        centerYConstraint.constant = self.verticalOffset;
     }
     
+    // If applicable, set the custom view's constraints
     if (_customView) {
-        [views setObject:_customView forKey:@"customView"];
-        [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[customView]|" options:0 metrics:nil views:views]];
-        [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[customView]|" options:0 metrics:nil views:views]];
-        
-        // Skips from any further configuration
-        return [super updateConstraints];;
+        [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[customView]|" options:0 metrics:nil views:@{@"customView":_customView}]];
+        [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[customView]|" options:0 metrics:nil views:@{@"customView":_customView}]];
     }
-    
-    CGFloat width = CGRectGetWidth(self.frame) ? : CGRectGetWidth([UIScreen mainScreen].bounds);
-    NSNumber *padding =  [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone ? @20 : @(roundf(width/16.0));
-    NSNumber *imgWidth = @(roundf(_imageView.image.size.width));
-    NSNumber *imgHeight = @(roundf(_imageView.image.size.height));
-    NSNumber *trailing = @(roundf((width-[imgWidth floatValue])/2.0));
-    
-    NSDictionary *metrics = NSDictionaryOfVariableBindings(padding,trailing,imgWidth,imgHeight);
-    
-    // Since any element could be missing from displaying, we need to create a dynamic string format
-    NSMutableArray *verticalSubviews = [NSMutableArray new];
-    
-    // Assign the image view's horizontal constraints
-    if (_imageView.superview) {
-        [views setObject:_imageView forKey:@"imageView"];
-        [verticalSubviews addObject:@"[imageView(imgHeight)]"];
-        
-        [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-trailing-[imageView(imgWidth)]-trailing-|"
-                                                                                 options:0 metrics:metrics views:views]];
-    }
-    
-    // Assign the title label's horizontal constraints
-    if ([self canShowTitle]) {
-        [views setObject:_titleLabel forKey:@"titleLabel"];
-        [verticalSubviews addObject:@"[titleLabel]"];
-        
-        [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-padding-[titleLabel]-padding-|"
-                                                                                 options:0 metrics:metrics views:views]];
-    }
-    // or removes from its superview
     else {
-        [_titleLabel removeFromSuperview];
-        _titleLabel = nil;
-    }
-    
-    // Assign the detail label's horizontal constraints
-    if ([self canShowDetail]) {
-        [views setObject:_detailLabel forKey:@"detailLabel"];
-        [verticalSubviews addObject:@"[detailLabel]"];
+        CGFloat width = CGRectGetWidth(self.frame) ? : CGRectGetWidth([UIScreen mainScreen].bounds);
+        CGFloat padding =  [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone ? 20.0 : roundf(width/16.0);
+        CGFloat verticalSpace = self.verticalSpace ? : 11.0;
         
-        [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-padding-[detailLabel]-padding-|"
-                                                                                 options:0 metrics:metrics views:views]];
-    }
-    // or removes from its superview
-    else {
-        [_detailLabel removeFromSuperview];
-        _detailLabel = nil;
-    }
-    
-    // Assign the button's horizontal constraints
-    if ([self canShowButton]) {
-        [views setObject:_button forKey:@"button"];
-        [verticalSubviews addObject:@"[button]"];
+        NSMutableArray *subviewStrings = [NSMutableArray array];
+        NSMutableDictionary *views = [NSMutableDictionary dictionary];
+        NSDictionary *metrics = @{@"padding": @(padding)};
         
-        [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-padding-[button]-padding-|"
-                                                                                 options:0 metrics:metrics views:views]];
+        // Assign the image view's horizontal constraints
+        if (_imageView.superview) {
+            
+            [subviewStrings addObject:@"imageView"];
+            views[[subviewStrings lastObject]] = _imageView;
+            
+            [self.contentView addConstraint:[self.contentView equallyRelatedConstraintWithView:_imageView attribute:NSLayoutAttributeCenterX]];
+        }
+        
+        // Assign the title label's horizontal constraints
+        if ([self canShowTitle]) {
+            
+            [subviewStrings addObject:@"titleLabel"];
+            views[[subviewStrings lastObject]] = _titleLabel;
+            
+            [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-padding-[titleLabel(>=0)]-padding-|"
+                                                                                     options:0 metrics:metrics views:views]];
+        }
+        // or removes from its superview
+        else {
+            [_titleLabel removeFromSuperview];
+            _titleLabel = nil;
+        }
+        
+        // Assign the detail label's horizontal constraints
+        if ([self canShowDetail]) {
+            
+            [subviewStrings addObject:@"detailLabel"];
+            views[[subviewStrings lastObject]] = _detailLabel;
+            
+            [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-padding-[detailLabel(>=0)]-padding-|"
+                                                                                     options:0 metrics:metrics views:views]];
+        }
+        // or removes from its superview
+        else {
+            [_detailLabel removeFromSuperview];
+            _detailLabel = nil;
+        }
+        
+        // Assign the button's horizontal constraints
+        if ([self canShowButton]) {
+            
+            [subviewStrings addObject:@"button"];
+            views[[subviewStrings lastObject]] = _button;
+            
+            [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-padding-[button(>=0)]-padding-|"
+                                                                                     options:0 metrics:metrics views:views]];
+        }
+        // or removes from its superview
+        else {
+            [_button removeFromSuperview];
+            _button = nil;
+        }
+        
+        
+        NSMutableString *verticalFormat = [NSMutableString new];
+        
+        // Build a dynamic string format for the vertical constraints, adding a margin between each element. Default is 11 pts.
+        for (int i = 0; i < subviewStrings.count; i++) {
+            
+            NSString *string = subviewStrings[i];
+            [verticalFormat appendFormat:@"[%@]", string];
+            
+            if (i < subviewStrings.count-1) {
+                [verticalFormat appendFormat:@"-(%.f)-", verticalSpace];
+            }
+        }
+        
+        // Assign the vertical constraints to the content view
+        if (verticalFormat.length > 0) {
+            [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:[NSString stringWithFormat:@"V:|%@|", verticalFormat]
+                                                                                     options:0 metrics:metrics views:views]];
+        }
     }
-    // or removes from its superview
-    else {
-        [_button removeFromSuperview];
-        _button = nil;
-    }
-    
+}
 
-    // Build the string format for the vertical constraints, adding a margin between each element. Default is 11.
-    NSString *verticalFormat = [verticalSubviews componentsJoinedByString:[NSString stringWithFormat:@"-(%.f)-", self.verticalSpace ?: 11]];
-    
-    // Assign the vertical constraints to the content view
-    if (verticalFormat.length > 0) {
-        [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:[NSString stringWithFormat:@"V:|%@|", verticalFormat]
-                                                                             options:0 metrics:metrics views:views]];
-    }
-    
-    [super updateConstraints];
+@end
+
+
+#pragma mark - UIView+DZNConstraintBasedLayoutExtensions
+
+@implementation UIView (DZNConstraintBasedLayoutExtensions)
+
+- (NSLayoutConstraint *)equallyRelatedConstraintWithView:(UIView *)view attribute:(NSLayoutAttribute)attribute
+{
+    return [NSLayoutConstraint constraintWithItem:view
+                                        attribute:attribute
+                                        relatedBy:NSLayoutRelationEqual
+                                           toItem:self
+                                        attribute:attribute
+                                       multiplier:1.0
+                                         constant:0.0];
 }
 
 @end

--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -32,7 +32,6 @@
 @property (nonatomic, assign) CGFloat verticalSpace;
 
 - (void)setupConstraints;
-- (void)removeAllConstraints;
 - (void)prepareForReuse;
 
 @end
@@ -398,7 +397,7 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
             }
         }
         
-        // Moves all its subviews and constraints
+        // Removing view resetting the view and its constraints it very important to guarantee a good state
         [view prepareForReuse];
         
         UIView *customView = [self dzn_customView];
@@ -805,6 +804,8 @@ NSString *dzn_implementationKey(id target, SEL selector)
     _imageView = nil;
     _button = nil;
     _customView = nil;
+    
+    [self removeAllConstraints];
 }
 
 

--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -689,7 +689,7 @@ NSString *dzn_implementationKey(id target, SEL selector)
         _titleLabel.textColor = [UIColor colorWithWhite:0.6 alpha:1.0];
         _titleLabel.textAlignment = NSTextAlignmentCenter;
         _titleLabel.lineBreakMode = NSLineBreakByWordWrapping;
-        _titleLabel.numberOfLines = 2;
+        _titleLabel.numberOfLines = 0;
         _titleLabel.accessibilityLabel = @"empty set title";
         
         [_contentView addSubview:_titleLabel];


### PR DESCRIPTION
Since we merged https://github.com/dzenbot/DZNEmptyDataSet/pull/93, with `dealloc` swizzling to remove the rotation observer, many of us started to experience crashes and memory issues (see #102, #103, #105, #108, etc.). I'm very sorry for the inconvenience caused 😕

### Problem: Rotation notification
*Why do we even need to observe the device rotation anyway?*

Because the way auto-layout was internally configured, it required to be notified on device orientation to re-configure-all-over-again :scream:. This was actually a very bad practice on auto-layout.

At first, to remove the observer, the technique was to set the `emptyDataSource` to nil in your view controller `dealloc` methods. This was tedious to do, and it wasn't an obvious thing to do either.
Swizzling `dealloc` didn't seem such a bad idea, to remove the internal observation transparently and automatically, so you wouldn't even care about this anymore. But at this point, it was a patch, of a patch, over another patch.

I tried to fix it in https://github.com/dzenbot/DZNEmptyDataSet/pull/104 without success. 😓

I then wanted to give it a try with @garfbargle 's [suggestion](https://github.com/dzenbot/DZNEmptyDataSet/issues/102#issuecomment-124276030), with an observer binder object. In a separate branch, I started to implement [this draft idea](https://github.com/dzenbot/DZNEmptyDataSet/issues/102#issuecomment-124585832), but line after line, it started to feel over-engineered for such a small little thing like 1 notification observer removal.

After scratching my head for several days around this, I decided to go back the root problem: the auto-layout setup was **just wrong**. Auto-layout is powerful enough to adjust to the device's bounds changes by its own.

### The solution: Simplified Auto layout configuration
- Configure view constraints once per data source update
- Avoid removing/adding view constraints constantly
- Better auto-layout configuration for centering content to its superview
- Specially, no need for any rotation notification observal/removal, no more swizzling!

Please, @garfbargle, @mythodeia, @flicker317, and others, could you give this PR a review, and if possible, test it and see if it does work proplery on your current setups?
This is probably the biggest refactor of this library, with a more scalable and cleaner approach.