### PR TITLE
Set accessibility identifiers instead of accessibility labels

### DIFF
--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -670,7 +670,7 @@ NSString *dzn_implementationKey(id target, SEL selector)
         _imageView.backgroundColor = [UIColor clearColor];
         _imageView.contentMode = UIViewContentModeScaleAspectFit;
         _imageView.userInteractionEnabled = NO;
-        _imageView.accessibilityLabel = @"empty set background image";
+        _imageView.accessibilityIdentifier = @"empty set background image";
         
         [_contentView addSubview:_imageView];
     }
@@ -690,7 +690,7 @@ NSString *dzn_implementationKey(id target, SEL selector)
         _titleLabel.textAlignment = NSTextAlignmentCenter;
         _titleLabel.lineBreakMode = NSLineBreakByWordWrapping;
         _titleLabel.numberOfLines = 0;
-        _titleLabel.accessibilityLabel = @"empty set title";
+        _titleLabel.accessibilityIdentifier = @"empty set title";
         
         [_contentView addSubview:_titleLabel];
     }
@@ -710,7 +710,7 @@ NSString *dzn_implementationKey(id target, SEL selector)
         _detailLabel.textAlignment = NSTextAlignmentCenter;
         _detailLabel.lineBreakMode = NSLineBreakByWordWrapping;
         _detailLabel.numberOfLines = 0;
-        _detailLabel.accessibilityLabel = @"empty set detail label";
+        _detailLabel.accessibilityIdentifier = @"empty set detail label";
         
         [_contentView addSubview:_detailLabel];
     }
@@ -726,7 +726,7 @@ NSString *dzn_implementationKey(id target, SEL selector)
         _button.backgroundColor = [UIColor clearColor];
         _button.contentHorizontalAlignment = UIControlContentHorizontalAlignmentCenter;
         _button.contentVerticalAlignment = UIControlContentVerticalAlignmentCenter;
-        _button.accessibilityLabel = @"empty set button";
+        _button.accessibilityIdentifier = @"empty set button";
         
         [_button addTarget:self action:@selector(didTapButton:) forControlEvents:UIControlEventTouchUpInside];
         


### PR DESCRIPTION
Accessibility labels should be localized and since those views (image view, title label, detail label and button) are not publicly exposed it’s impossible to change them.

Also, the best accessibility label for a UILabel is its text, which is the default when you don’t set any `accessibilityLabel` property.