### PR TITLE
Fixes gestures not passing through UITableViewWrapperView on iOS 7

### DIFF
--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -36,6 +36,30 @@
 
 @end
 
+@interface UITableView (DZNiOS7TableViewWrapperView)
+
+- (UIView *)dzn_tableViewWrapperView;
+
+@end
+
+@implementation UITableView (DZNiOS7TableViewWrapperView)
+
+- (UIView *)dzn_tableViewWrapperView {
+    if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_7_1 &&
+        floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_6_1 &&
+        [self isKindOfClass:[UITableView class]]) {
+        for (UIView *subview in [self subviews]) {
+            if ([subview isKindOfClass:NSClassFromString(@"UITableViewWrapperView")]) {
+                return subview;
+            }
+        }
+    }
+    
+    return nil;
+}
+
+@end
+
 
 #pragma mark - UIScrollView+EmptyDataSet
 
@@ -287,6 +311,10 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
 
 - (void)dzn_didAppear
 {
+    if ([self isKindOfClass:[UITableView class]]) {
+        [(UITableView *)self dzn_tableViewWrapperView].userInteractionEnabled = NO;
+    }
+    
     if (self.emptyDataSetDelegate && [self.emptyDataSetDelegate respondsToSelector:@selector(emptyDataSetDidAppear:)]) {
         [self.emptyDataSetDelegate emptyDataSetDidAppear:self];
     }
@@ -301,6 +329,10 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
 
 - (void)dzn_didDisappear
 {
+    if ([self isKindOfClass:[UITableView class]]) {
+        [(UITableView *)self dzn_tableViewWrapperView].userInteractionEnabled = YES;
+    }
+    
     if (self.emptyDataSetDelegate && [self.emptyDataSetDelegate respondsToSelector:@selector(emptyDataSetDidDisappear:)]) {
         [self.emptyDataSetDelegate emptyDataSetDidDisappear:self];
     }


### PR DESCRIPTION
This fixes #47

In a nutshell, this pull request toggles `UITableViewWrapperView`'s `userInteractionEnabled` property off or on when the `emptyDataSetView` appears or disappears.

The main concern here I suppose is the check for "UITableViewWrapperView" since that is a private API. This call is guarded by a version check, so shouldn't break in future releases, but I'm not sure if checking for this class could cause an app to be rejected.

For what it's worth, validating an Archive containing this code didn't cause any private API flags to be raised.