### PR TITLE
Delegate gets the tapped view/button

### DIFF
--- a/Examples/Applications/Applications/DetailViewController.m
+++ b/Examples/Applications/Applications/DetailViewController.m
@@ -867,13 +867,14 @@
     return YES;
 }
 
-- (void)emptyDataSetDidTapView:(UIScrollView *)scrollView
+- (void)emptyDataSet:(UIScrollView *)scrollView didTapView:(UIView *)view
 {
     NSLog(@"%s",__FUNCTION__);
 }
 
-- (void)emptyDataSetDidTapButton:(UIScrollView *)scrollView
+- (void)emptyDataSet:(UIScrollView *)scrollView didTapButton:(UIButton *)button
 {
+
     NSLog(@"%s",__FUNCTION__);
 }
 

--- a/Examples/Applications/Applications/MainViewController.m
+++ b/Examples/Applications/Applications/MainViewController.m
@@ -151,13 +151,14 @@
     return YES;
 }
 
-- (void)emptyDataSetDidTapView:(UIScrollView *)scrollView
+- (void)emptyDataSet:(UIScrollView *)scrollView didTapView:(UIView *)view
 {
     NSLog(@"%s",__FUNCTION__);
 }
 
-- (void)emptyDataSetDidTapButton:(UIScrollView *)scrollView
+- (void)emptyDataSet:(UIScrollView *)scrollView didTapButton:(UIButton *)button
 {
+
     UISearchBar *searchBar = self.searchDisplayController.searchBar;
 
     NSURL *URL = [NSURL URLWithString:[NSString stringWithFormat:@"http://itunes.com/apps/%@", searchBar.text]];

--- a/Examples/Colors/Colors/CollectionViewController.m
+++ b/Examples/Colors/Colors/CollectionViewController.m
@@ -196,13 +196,15 @@ static NSString *CellIdentifier = @"ColorViewCell";
     return YES;
 }
 
-- (void)emptyDataSetDidTapView:(UIScrollView *)scrollView
+- (void)emptyDataSet:(UIScrollView *)scrollView didTapView:(UIView *)view
 {
+
     NSLog(@"%s",__FUNCTION__);
 }
 
-- (void)emptyDataSetDidTapButton:(UIScrollView *)scrollView
+- (void)emptyDataSet:(UIScrollView *)scrollView didTapButton:(UIButton *)button
 {
+
     NSLog(@"%s",__FUNCTION__);
 }
 

--- a/Examples/Colors/Colors/SearchViewController.m
+++ b/Examples/Colors/Colors/SearchViewController.m
@@ -235,13 +235,15 @@
     return NO;
 }
 
-- (void)emptyDataSetDidTapView:(UIScrollView *)scrollView
+- (void)emptyDataSet:(UIScrollView *)scrollView didTapView:(UIView *)view
 {
+
     [self.searchDisplayController setActive:NO animated:YES];
 }
 
-- (void)emptyDataSetDidTapButton:(UIScrollView *)scrollView
+- (void)emptyDataSet:(UIScrollView *)scrollView didTapButton:(UIButton *)button
 {
+
     NSLog(@"%s",__FUNCTION__);
 }
 

--- a/Examples/Colors/Colors/TableViewController.m
+++ b/Examples/Colors/Colors/TableViewController.m
@@ -132,8 +132,9 @@
     return NO;
 }
 
-- (void)emptyDataSetDidTapView:(UIScrollView *)scrollView
+- (void)emptyDataSet:(UIScrollView *)scrollView didTapView:(UIView *)view
 {
+
     NSLog(@"%s",__FUNCTION__);
 }
 

--- a/Examples/Countries/Countries/MainViewController.m
+++ b/Examples/Countries/Countries/MainViewController.m
@@ -233,15 +233,17 @@
     return YES;
 }
 
-- (void)emptyDataSetDidTapView:(UIScrollView *)scrollView
+- (void)emptyDataSet:(UIScrollView *)scrollView didTapView:(UIView *)view
 {
+
     if ([self.searchBar isFirstResponder]) {
         [self.searchBar resignFirstResponder];
     }
 }
 
-- (void)emptyDataSetDidTapButton:(UIScrollView *)scrollView
+- (void)emptyDataSet:(UIScrollView *)scrollView didTapButton:(UIButton *)button
 {
+
     if ([self.searchBar isFirstResponder] && UIDeviceOrientationIsLandscape([UIDevice currentDevice].orientation)) {
         return;
     }

--- a/Source/UIScrollView+EmptyDataSet.h
+++ b/Source/UIScrollView+EmptyDataSet.h
@@ -182,6 +182,7 @@
  Use this method either to resignFirstResponder of a textfield or searchBar.
  
  @param scrollView A scrollView subclass informing the delegate.
+ @param view the view tapped by the user
  */
 - (void)emptyDataSet:(UIScrollView *)scrollView didTapView:(UIView *)view;
 
@@ -189,6 +190,7 @@
  Tells the delegate that the action button was tapped.
  
  @param scrollView A scrollView subclass informing the delegate.
+ @param button the button tapped by the user
  */
 - (void)emptyDataSet:(UIScrollView *)scrollView didTapButton:(UIButton *)button;
 

--- a/Source/UIScrollView+EmptyDataSet.h
+++ b/Source/UIScrollView+EmptyDataSet.h
@@ -183,14 +183,14 @@
  
  @param scrollView A scrollView subclass informing the delegate.
  */
-- (void)emptyDataSetDidTapView:(UIScrollView *)scrollView;
+- (void)emptyDataSet:(UIScrollView *)scrollView didTapView:(UIView *)view;
 
 /**
  Tells the delegate that the action button was tapped.
  
  @param scrollView A scrollView subclass informing the delegate.
  */
-- (void)emptyDataSetDidTapButton:(UIScrollView *)scrollView;
+- (void)emptyDataSet:(UIScrollView *)scrollView didTapButton:(UIButton *)button;
 
 /**
  Tells the delegate that the empty data set will appear.

--- a/Source/UIScrollView+EmptyDataSet.h
+++ b/Source/UIScrollView+EmptyDataSet.h
@@ -177,6 +177,22 @@
  */
 - (BOOL)emptyDataSetShouldAllowScroll:(UIScrollView *)scrollView;
 
+
+/**
+ Tells the delegate that the empty dataset view was tapped.
+ Use this method either to resignFirstResponder of a textfield or searchBar.
+ 
+ @param scrollView A scrollView subclass informing the delegate.
+ */
+- (void)emptyDataSetDidTapView:(UIScrollView *)scrollView DEPRECATED_MSG_ATTRIBUTE("Use emptyDataSet:didTapView:");
+
+/**
+ Tells the delegate that the action button was tapped.
+ 
+ @param scrollView A scrollView subclass informing the delegate.
+ */
+- (void)emptyDataSetDidTapButton:(UIScrollView *)scrollView DEPRECATED_MSG_ATTRIBUTE("Use emptyDataSet:didTapButton:");
+
 /**
  Tells the delegate that the empty dataset view was tapped.
  Use this method either to resignFirstResponder of a textfield or searchBar.

--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -308,15 +308,15 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
 
 - (void)dzn_didTapContentView:(id)sender
 {
-    if (self.emptyDataSetDelegate && [self.emptyDataSetDelegate respondsToSelector:@selector(emptyDataSetDidTapView:)]) {
-        [self.emptyDataSetDelegate emptyDataSetDidTapView:self];
+    if (self.emptyDataSetDelegate && [self.emptyDataSetDelegate respondsToSelector:@selector(emptyDataSet:didTapView:)]) {
+        [self.emptyDataSetDelegate emptyDataSet:self didTapView:sender];
     }
 }
 
 - (void)dzn_didTapDataButton:(id)sender
 {
-    if (self.emptyDataSetDelegate && [self.emptyDataSetDelegate respondsToSelector:@selector(emptyDataSetDidTapButton:)]) {
-        [self.emptyDataSetDelegate emptyDataSetDidTapButton:self];
+    if (self.emptyDataSetDelegate && [self.emptyDataSetDelegate respondsToSelector:@selector(emptyDataSet:didTapButton:)]) {
+        [self.emptyDataSetDelegate emptyDataSet:self didTapButton:sender];
     }
 }
 

--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -311,6 +311,12 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
     if (self.emptyDataSetDelegate && [self.emptyDataSetDelegate respondsToSelector:@selector(emptyDataSet:didTapView:)]) {
         [self.emptyDataSetDelegate emptyDataSet:self didTapView:sender];
     }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    else if (self.emptyDataSetDelegate && [self.emptyDataSetDelegate respondsToSelector:@selector(emptyDataSetDidTapView:)]) {
+        [self.emptyDataSetDelegate emptyDataSetDidTapView:self];
+    }
+#pragma clang diagnostic pop
 }
 
 - (void)dzn_didTapDataButton:(id)sender
@@ -318,6 +324,12 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
     if (self.emptyDataSetDelegate && [self.emptyDataSetDelegate respondsToSelector:@selector(emptyDataSet:didTapButton:)]) {
         [self.emptyDataSetDelegate emptyDataSet:self didTapButton:sender];
     }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    else if (self.emptyDataSetDelegate && [self.emptyDataSetDelegate respondsToSelector:@selector(emptyDataSetDidTapButton:)]) {
+        [self.emptyDataSetDelegate emptyDataSetDidTapButton:self];
+    }
+#pragma clang diagnostic pop
 }
 
 


### PR DESCRIPTION
Changed the delegate methods slightly such that they include not only the scrollview but also the view or the button tapped by the user. This helps a lot for instance to correctly position the popover when showing a UIAlertController from the tapped button on an iPad.