### PR TITLE
Use UIButtonTypeSystem instead of UIButtonTypeCustom to get tap states.

### DIFF
--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -764,7 +764,7 @@ NSString *dzn_implementationKey(id target, SEL selector)
 {
     if (!_button)
     {
-        _button = [UIButton buttonWithType:UIButtonTypeCustom];
+        _button = [UIButton buttonWithType:UIButtonTypeSystem];
         _button.translatesAutoresizingMaskIntoConstraints = NO;
         _button.backgroundColor = [UIColor clearColor];
         _button.contentHorizontalAlignment = UIControlContentHorizontalAlignmentCenter;


### PR DESCRIPTION
UIButtonTypeCustom does not provide any tap state feedback to the user by default. UIButtonTypeSystem does and fits better into the system.

Example:

As it is now with UIButtonTypeCustom:
![withcustom](https://cloud.githubusercontent.com/assets/2890/11222053/200438c6-8d1d-11e5-8f10-dabfe686d7ac.gif)

With UIButtonTypeSystem:
![withsystem](https://cloud.githubusercontent.com/assets/2890/11222062/2816c3bc-8d1d-11e5-8ad4-4f1c16f5c65d.gif)
