### PR TITLE
Force the layoutIfNeeded to occur without animation in cases where th…

### DIFF
--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -504,7 +504,10 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
         view.fadeInOnDisplay = [self dzn_shouldFadeIn];
         
         [view setupConstraints];
-        [view layoutIfNeeded];
+        
+        [UIView performWithoutAnimation:^{
+            [view layoutIfNeeded];            
+        }];
         
         // Configure scroll permission
         self.scrollEnabled = [self dzn_isScrollAllowed];


### PR DESCRIPTION
…e container is being animated into view while the empty view is coming on screen (eg. master panel in UISplitViewController sliding in from left)