### PR TITLE
forcing to display empty DataSet if needed when items count is more than 0

### DIFF
--- a/Source/UIScrollView+EmptyDataSet.h
+++ b/Source/UIScrollView+EmptyDataSet.h
@@ -172,6 +172,15 @@
 - (BOOL)emptyDataSetShouldFadeIn:(UIScrollView *)scrollView;
 
 /**
+ *  Ask the delegate to know if the empty dataset should be forced to render and display when items count is more than 0. Default is NO
+ *
+ *  @param scrollView scrollView A scrollView subclass object informing the delegate.
+ *
+ *  @return YES if empty dataset should be forced to display
+ */
+- (BOOL)emptyDataSetShouldBeForcedToDisplay:(UIScrollView *)scrollView;
+
+/**
  Asks the delegate to know if the empty dataset should be rendered and displayed. Default is YES.
  
  @param scrollView A scrollView subclass object informing the delegate.

--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -291,6 +291,14 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
     return YES;
 }
 
+- (BOOL)dzn_shouldBeForcedToDisplay {
+    if (self.emptyDataSetDelegate && [self.emptyDataSetDelegate respondsToSelector:@selector(emptyDataSetShouldBeForcedToDisplay:)]) {
+        return [self.emptyDataSetDelegate emptyDataSetShouldBeForcedToDisplay:self];
+    }
+    
+    return NO;
+}
+
 - (BOOL)dzn_isTouchAllowed
 {
     if (self.emptyDataSetDelegate && [self.emptyDataSetDelegate respondsToSelector:@selector(emptyDataSetShouldAllowTouch:)]) {
@@ -423,7 +431,7 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
         return;
     }
     
-    if ([self dzn_shouldDisplay] && [self dzn_itemsCount] == 0)
+    if (([self dzn_shouldDisplay] && [self dzn_itemsCount] == 0) || [self dzn_shouldBeForcedToDisplay])
     {
         // Notifies that the empty dataset view will appear
         [self dzn_willAppear];


### PR DESCRIPTION
It is useful for table view which contains some additional static rows beside dynamic rows.
For example:
TableView has got 2 sections first one with 2 static cells and second one with dynamic cells. I would like to display empty data set when second section has got any rows, so I have to use emptyDataSetShouldBeForcedToDisplay delegate method to do that, because default implementation allows showing empty data set only when items count is equal 0 and in this case items count is equal 2