### PR TITLE
Fixes #191 and allows taps on UIControls to be accepted instead of tap gesture on content view.

### DIFF
--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -895,8 +895,6 @@ NSString *dzn_implementationKey(id target, SEL selector)
     
     // If applicable, set the custom view's constraints
     if (_customView) {
-        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[contentView]|" options:0 metrics:nil views:@{@"contentView": self.contentView}]];
-        
         [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[customView]|" options:0 metrics:nil views:@{@"customView":_customView}]];
         [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[customView]|" options:0 metrics:nil views:@{@"customView":_customView}]];
     }

--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -647,6 +647,10 @@ NSString *dzn_implementationKey(id target, SEL selector)
 
 #pragma mark - UIGestureRecognizerDelegate Methods
 
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch {
+    return ![touch.view isKindOfClass:[UIControl class]];
+}
+
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
 {
     if ([gestureRecognizer.view isEqual:self.emptyDataSetView]) {


### PR DESCRIPTION
Fixes #191. Removed vertical pinning on custom view and allows the existing centerY constraint to take effect, preventing the custom view from stretching.

Tap gesture: currently, if a `UIControl` subclass is tapped, the tap gesture gets the touch and cancels the touch in the `UIControl`. In the [Event Handling for iOS](https://developer.apple.com/library/ios/documentation/EventHandling/Conceptual/EventHandlingiPhoneOS/GestureRecognizer_basics/GestureRecognizer_basics.html#//apple_ref/doc/uid/TP40009541-CH2-SW4) document, it outline how, when system controls are in a parent with a gesture, the control receives the touch instead of the parent's gesture. Added the delegate method to prevent the gesture from receiving touches if the subview touched is a `UIControl` to mimic this behaviour.