### PR TITLE
Better deprecated macro

### DIFF
--- a/Examples/Applications/Applications/MainViewController.m
+++ b/Examples/Applications/Applications/MainViewController.m
@@ -123,11 +123,10 @@
     return [UIColor whiteColor];
 }
 
-- (CGPoint)offsetForEmptyDataSet:(UIScrollView *)scrollView
+- (CGFloat)verticalOffsetForEmptyDataSet:(UIScrollView *)scrollView
 {
-    return CGPointMake(0, -64.0);
+    return -64.0;
 }
-
 
 #pragma mark - DZNEmptyDataSetDelegate Methods
 

--- a/Source/UIScrollView+EmptyDataSet.h
+++ b/Source/UIScrollView+EmptyDataSet.h
@@ -142,7 +142,7 @@
  @param scrollView A scrollView subclass object informing the delegate.
  @return The offset for vertical and horizontal alignment.
  */
-- (CGPoint)offsetForEmptyDataSet:(UIScrollView *)scrollView DEPRECATED_MSG_ATTRIBUTE("Use -verticalOffsetForEmptyDataSet:");
+- (CGPoint)offsetForEmptyDataSet:(UIScrollView *)scrollView DZNEmptyDataSetDeprecated(-verticalOffsetForEmptyDataSet:);
 - (CGFloat)verticalOffsetForEmptyDataSet:(UIScrollView *)scrollView;
 
 /**
@@ -212,14 +212,14 @@
  
  @param scrollView A scrollView subclass informing the delegate.
  */
-- (void)emptyDataSetDidTapView:(UIScrollView *)scrollView DEPRECATED_MSG_ATTRIBUTE("Use emptyDataSet:didTapView:");
+- (void)emptyDataSetDidTapView:(UIScrollView *)scrollView DZNEmptyDataSetDeprecated(-emptyDataSet:didTapView:);
 
 /**
  Tells the delegate that the action button was tapped.
  
  @param scrollView A scrollView subclass informing the delegate.
  */
-- (void)emptyDataSetDidTapButton:(UIScrollView *)scrollView DEPRECATED_MSG_ATTRIBUTE("Use emptyDataSet:didTapButton:");
+- (void)emptyDataSetDidTapButton:(UIScrollView *)scrollView DZNEmptyDataSetDeprecated(-emptyDataSet:didTapButton:);
 
 /**
  Tells the delegate that the empty dataset view was tapped.

--- a/Source/UIScrollView+EmptyDataSet.h
+++ b/Source/UIScrollView+EmptyDataSet.h
@@ -267,3 +267,6 @@
 - (void)emptyDataSetDidDisappear:(UIScrollView *)scrollView;
 
 @end
+
+#undef DZNEmptyDataSetDeprecated
+

--- a/Source/UIScrollView+EmptyDataSet.h
+++ b/Source/UIScrollView+EmptyDataSet.h
@@ -13,6 +13,8 @@
 @protocol DZNEmptyDataSetSource;
 @protocol DZNEmptyDataSetDelegate;
 
+#define DZNEmptyDataSetDeprecated(instead) DEPRECATED_MSG_ATTRIBUTE(" Use " # instead " instead")
+
 /**
  A drop-in UITableView/UICollectionView superclass category for showing empty datasets whenever the view has no content to display.
  @discussion It will work automatically, by just conforming to DZNEmptyDataSetSource, and returning the data you want to show.


### PR DESCRIPTION
Better deprecated macro. Doesn't do much things, but I like it as I don't have to type the words 'Use' and 'instead' everytime.
From my repo: https://github.com/WenchaoD/FSCalendar/blob/master/FSCalendar/FSCalendarConstance.h#L47

For `properties`:
https://github.com/WenchaoD/FSCalendar/blob/master/FSCalendar/FSCalendar.h#L183
For `methods`:
https://github.com/WenchaoD/FSCalendar/blob/master/FSCalendar/FSCalendar.h#L184

Results:
<img width="882" alt="screen shot 2016-03-14 at 14 34 23" src="https://cloud.githubusercontent.com/assets/5186464/13736777/95a4ad72-e9f2-11e5-875b-e3474f1bb3f4.png">

