### PR TITLE
Import header path fixed (tested with Cocoapods)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For complete documentation, [visit CocoaPods' auto-generated doc](http://cocoado
 
 ### Import
 ```objc
-#import "UIScrollView+EmptyDataSet.h"
+#import "DZNEmptyDataSet/UIScrollView+EmptyDataSet.h"
 ```
 
 ### Protocol Conformance


### PR DESCRIPTION
With Cocoapods I need to add "DZNEmptyDataSet/" in front of the header file name. Otherwise the header isn't found.