### PR TITLE
Wrap unsafe OBJC_ASSOCIATION_ASSIGN references with containers

### DIFF
--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -17,6 +17,14 @@
 
 @end
 
+@interface DZNWeakObjectContainer : NSObject
+
+@property (nonatomic, readonly, weak) id object;
+
+- (instancetype)initWithObject:(id)object;
+
+@end
+
 @interface DZNEmptyDataSetView : UIView
 
 @property (nonatomic, readonly) UIView *contentView;
@@ -56,12 +64,14 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
 
 - (id<DZNEmptyDataSetSource>)emptyDataSetSource
 {
-    return objc_getAssociatedObject(self, kEmptyDataSetSource);
+    DZNWeakObjectContainer *container = objc_getAssociatedObject(self, kEmptyDataSetSource);
+    return container.object;
 }
 
 - (id<DZNEmptyDataSetDelegate>)emptyDataSetDelegate
 {
-    return objc_getAssociatedObject(self, kEmptyDataSetDelegate);
+    DZNWeakObjectContainer *container = objc_getAssociatedObject(self, kEmptyDataSetDelegate);
+    return container.object;
 }
 
 - (BOOL)isEmptyDataSetVisible
@@ -378,7 +388,7 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
         [self dzn_invalidate];
     }
     
-    objc_setAssociatedObject(self, kEmptyDataSetSource, datasource, OBJC_ASSOCIATION_ASSIGN);
+    objc_setAssociatedObject(self, kEmptyDataSetSource, [[DZNWeakObjectContainer alloc] initWithObject:datasource], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     
     // We add method sizzling for injecting -dzn_reloadData implementation to the native -reloadData implementation
     [self swizzleIfPossible:@selector(reloadData)];
@@ -395,7 +405,7 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
         [self dzn_invalidate];
     }
     
-    objc_setAssociatedObject(self, kEmptyDataSetDelegate, delegate, OBJC_ASSOCIATION_ASSIGN);
+    objc_setAssociatedObject(self, kEmptyDataSetDelegate, [[DZNWeakObjectContainer alloc] initWithObject:delegate], OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 
@@ -1029,6 +1039,21 @@ NSString *dzn_implementationKey(id target, SEL selector)
                                         attribute:attribute
                                        multiplier:1.0
                                          constant:0.0];
+}
+
+@end
+
+#pragma mark - DZNWeakObjectContainer
+
+@implementation DZNWeakObjectContainer
+
+- (instancetype)initWithObject:(id)object
+{
+    self = [super init];
+    if (self) {
+        _object = object;
+    }
+    return self;
 }
 
 @end


### PR DESCRIPTION
Proposed fix to #184

[Quoting NSHipster :](http://nshipster.com/associated-objects/#associative-object-behaviors)

> Weak associations to objects made with OBJC_ASSOCIATION_ASSIGN are not zero weak references,
> but rather follow a behavior similar to unsafe_unretained, which means that one should be cautious when
> accessing weakly associated objects within an implementation.

Wrapping the object with a container and referencing that container with `OBJC_ASSOCIATION_RETAIN_NONATOMIC ` allows the use of a safe `weak` property that will get nilled out when the object is deallocated.

Credit to @0xced for the [stackoverflow answer](http://stackoverflow.com/a/27035233/590010)

Fixes #184 