### PR TITLE
Add support for background gradient

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Please read this very interesting article about [*Designing For The Empty States
 * Gives multiple possibilities of layout and appearance, by showing an image and/or title label and/or description label and/or button.
 * Uses NSAttributedString for easier appearance customisation.
 * Uses auto-layout to automagically center the content to the tableview, with auto-rotation support. Also accepts custom vertical and horizontal alignment.
-* Background color customisation.
+* Background color customisation, including gradient.
 * Allows tap gesture on the whole tableview rectangle (useful for resigning first responder or similar actions).
 * For more advanced customisation, it allows a custom view.
 * Compatible with Storyboard.
@@ -154,6 +154,16 @@ The background color for the empty state:
 - (UIColor *)backgroundColorForEmptyDataSet:(UIScrollView *)scrollView
 {
     return [UIColor whiteColor];
+}
+```
+
+The background gradient for the empty state:
+```objc
+- (CAGradientLayer *)backgroundGradientForEmptyDataSet:(UIScrollView *)scrollView
+{
+    CAGradientLayer *backgroundGradient = [CAGradientLayer layer];
+    backgroundGradient.colors = @[(id)[[UIColor whiteColor] CGColor], (id)[[UIColor blackColor] CGColor]];
+    return backgroundGradient;
 }
 ```
 

--- a/Source/UIScrollView+EmptyDataSet.h
+++ b/Source/UIScrollView+EmptyDataSet.h
@@ -126,6 +126,16 @@
  */
 - (UIColor *)backgroundColorForEmptyDataSet:(UIScrollView *)scrollView;
 
+
+/**
+ Asks the data source for the background gradient of the dataset. Default is none.
+ 
+ @param scrollView A scrollView subclass object informing the data source.
+ @return A gradient to be applied to the dataset background view.
+ */
+- (CAGradientLayer *)backgroundGradientForEmptyDataSet:(UIScrollView *)scrollView;
+
+
 /**
  Asks the data source for a custom view to be displayed instead of the default views such as labels, imageview and button. Default is nil.
  Use this method to show an activity view indicator for loading feedback, or for complete custom empty data set.

--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -255,6 +255,16 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
     return [UIColor clearColor];
 }
 
+- (void)dzn_dataSetBackgroundGradient
+{
+    if (self.emptyDataSetSource && [self.emptyDataSetSource respondsToSelector:@selector(backgroundGradientForEmptyDataSet:)]) {
+        CAGradientLayer *gradient = [self.emptyDataSetSource backgroundGradientForEmptyDataSet:self];
+        if (gradient) NSAssert([gradient isKindOfClass:[CAGradientLayer class]], @"You must return a valid CAGradientLayer object for -backgroundGradientForEmptyDataSet:");
+        gradient.frame = self.bounds;
+        [self.layer insertSublayer:gradient atIndex:0];
+    }
+}
+
 - (UIView *)dzn_customView
 {
     if (self.emptyDataSetSource && [self.emptyDataSetSource respondsToSelector:@selector(customViewForEmptyDataSet:)]) {
@@ -521,6 +531,7 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
         
         // Configure the empty dataset view
         view.backgroundColor = [self dzn_dataSetBackgroundColor];
+        [self dzn_dataSetBackgroundGradient]
         view.hidden = NO;
         view.clipsToBounds = YES;
         


### PR DESCRIPTION
This PR adds support to use a background gradient (using `CAGradientLayer`) to the empty state view.

README has been updated to instruct how to handle it, with the example of a simple B&W gradient.