### PR TITLE
Fix for getting touch events in customView UIControl elements

### DIFF
--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -925,6 +925,7 @@ Class dzn_baseClassToSwizzleForTarget(id target)
     [self addConstraint:centerXConstraint];
     [self addConstraint:centerYConstraint];
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[contentView]|" options:0 metrics:nil views:@{@"contentView": self.contentView}]];
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[contentView]|" options:0 metrics:nil views:@{@"contentView": self.contentView}]];
     
     // When a custom offset is available, we adjust the vertical constraints' constants
     if (self.verticalOffset != 0 && self.constraints.count > 0) {


### PR DESCRIPTION
Hi 

This is something I've already fixed some time ago in https://github.com/dzenbot/DZNEmptyDataSet/pull/172 ... 
> Because height constraint is not set for contentView, customView height is 0 and hitTest is failing on UIControl elements in custom view.

It's gone now so I will make a fresh pull request :)