### PR TITLE
Add nullability annotations for improved Swift interop

### DIFF
--- a/Source/UIScrollView+EmptyDataSet.h
+++ b/Source/UIScrollView+EmptyDataSet.h
@@ -10,6 +10,8 @@
 
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol DZNEmptyDataSetSource;
 @protocol DZNEmptyDataSetDelegate;
 
@@ -22,9 +24,9 @@
 @interface UIScrollView (EmptyDataSet)
 
 /** The empty datasets data source. */
-@property (nonatomic, weak) IBOutlet id <DZNEmptyDataSetSource> emptyDataSetSource;
+@property (nonatomic, weak, nullable) IBOutlet id <DZNEmptyDataSetSource> emptyDataSetSource;
 /** The empty datasets delegate. */
-@property (nonatomic, weak) IBOutlet id <DZNEmptyDataSetDelegate> emptyDataSetDelegate;
+@property (nonatomic, weak, nullable) IBOutlet id <DZNEmptyDataSetDelegate> emptyDataSetDelegate;
 /** YES if any empty dataset is visible. */
 @property (nonatomic, readonly, getter = isEmptyDataSetVisible) BOOL emptyDataSetVisible;
 
@@ -51,7 +53,7 @@
  @param scrollView A scrollView subclass informing the data source.
  @return An attributed string for the dataset title, combining font, text color, text pararaph style, etc.
  */
-- (NSAttributedString *)titleForEmptyDataSet:(UIScrollView *)scrollView;
+- (nullable NSAttributedString *)titleForEmptyDataSet:(UIScrollView *)scrollView;
 
 /**
  Asks the data source for the description of the dataset.
@@ -60,7 +62,7 @@
  @param scrollView A scrollView subclass informing the data source.
  @return An attributed string for the dataset description text, combining font, text color, text pararaph style, etc.
  */
-- (NSAttributedString *)descriptionForEmptyDataSet:(UIScrollView *)scrollView;
+- (nullable NSAttributedString *)descriptionForEmptyDataSet:(UIScrollView *)scrollView;
 
 /**
  Asks the data source for the image of the dataset.
@@ -68,7 +70,7 @@
  @param scrollView A scrollView subclass informing the data source.
  @return An image for the dataset.
  */
-- (UIImage *)imageForEmptyDataSet:(UIScrollView *)scrollView;
+- (nullable UIImage *)imageForEmptyDataSet:(UIScrollView *)scrollView;
 
 
 /**
@@ -77,7 +79,7 @@
  @param scrollView A scrollView subclass object informing the data source.
  @return A color to tint the image of the dataset.
  */
-- (UIColor *)imageTintColorForEmptyDataSet:(UIScrollView *)scrollView;
+- (nullable UIColor *)imageTintColorForEmptyDataSet:(UIScrollView *)scrollView;
 
 /**
  *  Asks the data source for the image animation of the dataset.
@@ -86,7 +88,7 @@
  *
  *  @return image animation
  */
-- (CAAnimation *) imageAnimationForEmptyDataSet:(UIScrollView *) scrollView;
+- (nullable CAAnimation *)imageAnimationForEmptyDataSet:(UIScrollView *)scrollView;
 
 /**
  Asks the data source for the title to be used for the specified button state.
@@ -96,7 +98,7 @@
  @param state The state that uses the specified title. The possible values are described in UIControlState.
  @return An attributed string for the dataset button title, combining font, text color, text pararaph style, etc.
  */
-- (NSAttributedString *)buttonTitleForEmptyDataSet:(UIScrollView *)scrollView forState:(UIControlState)state;
+- (nullable NSAttributedString *)buttonTitleForEmptyDataSet:(UIScrollView *)scrollView forState:(UIControlState)state;
 
 /**
  Asks the data source for the image to be used for the specified button state.
@@ -106,7 +108,7 @@
  @param state The state that uses the specified title. The possible values are described in UIControlState.
  @return An image for the dataset button imageview.
  */
-- (UIImage *)buttonImageForEmptyDataSet:(UIScrollView *)scrollView forState:(UIControlState)state;
+- (nullable UIImage *)buttonImageForEmptyDataSet:(UIScrollView *)scrollView forState:(UIControlState)state;
 
 /**
  Asks the data source for a background image to be used for the specified button state.
@@ -116,7 +118,7 @@
  @param state The state that uses the specified image. The values are described in UIControlState.
  @return An attributed string for the dataset button title, combining font, text color, text pararaph style, etc.
  */
-- (UIImage *)buttonBackgroundImageForEmptyDataSet:(UIScrollView *)scrollView forState:(UIControlState)state;
+- (nullable UIImage *)buttonBackgroundImageForEmptyDataSet:(UIScrollView *)scrollView forState:(UIControlState)state;
 
 /**
  Asks the data source for the background color of the dataset. Default is clear color.
@@ -124,7 +126,7 @@
  @param scrollView A scrollView subclass object informing the data source.
  @return A color to be applied to the dataset background view.
  */
-- (UIColor *)backgroundColorForEmptyDataSet:(UIScrollView *)scrollView;
+- (nullable UIColor *)backgroundColorForEmptyDataSet:(UIScrollView *)scrollView;
 
 /**
  Asks the data source for a custom view to be displayed instead of the default views such as labels, imageview and button. Default is nil.
@@ -134,7 +136,7 @@
  @param scrollView A scrollView subclass object informing the delegate.
  @return The custom view.
  */
-- (UIView *)customViewForEmptyDataSet:(UIScrollView *)scrollView;
+- (nullable UIView *)customViewForEmptyDataSet:(UIScrollView *)scrollView;
 
 /**
  Asks the data source for a offset for vertical and horizontal alignment of the content. Default is CGPointZero.
@@ -278,3 +280,4 @@
 
 #undef DZNEmptyDataSetDeprecated
 
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
This adds nullability to the Objective-C header for improved interoperability with Swift so that each member is not imported as an implicitly unwrapped optional.

This will not break compatibility of existing Swift users of this library however they will receive a warning in Xcode since the type signatures will no longer match. Thankfully Xcode provides a fix-it which will help migration.