### PR TITLE
Revert #259

### DIFF
--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -685,6 +685,13 @@ Class dzn_baseClassToSwizzleForTarget(id target)
 
 #pragma mark - UIGestureRecognizerDelegate Methods
 
+// This is necessary to allow touches to pass through to any UIControl that is tapped within a custom view. Otherwise,
+// the tap gesture on the DZNEmptyDataSetView gets the touch first which isn't the desired behaviour. The tap gesture
+// should only get touch events if the view that was tapped is not a UIControl
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch {
+    return ![touch.view isKindOfClass:[UIControl class]];
+}
+
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
 {
     if ([gestureRecognizer.view isEqual:self.emptyDataSetView]) {


### PR DESCRIPTION
If a custom view has a UIControl subclass, the -gestureRecognizer:shouldReceiveTouch: call is necessary to allow touches to pass through to the control immediately. Without this call, touches are delayed, and the touch up action on the control doesn't fire unless the control is tapped for an extended period of time.

The call here is checking to see if the tap gesture on the DZNEmptyDataSetView should receive touches. If the tapped view is a UIControl, the gesture recognizer shouldn't receive any touches and should instead pass them along to the UIControl for processing.