### PR TITLE
fix retain cycle warning

### DIFF
--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -145,7 +145,7 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
         
         UICollectionView *collectionView = (UICollectionView *)self;
         id <UICollectionViewDataSource> dataSource = collectionView.dataSource;
-
+        
         NSInteger sections = 1;
         
         if (dataSource && [dataSource respondsToSelector:@selector(numberOfSectionsInCollectionView:)]) {
@@ -738,7 +738,8 @@ Class dzn_baseClassToSwizzleForTarget(id target)
     CGRect superviewBounds = self.superview.bounds;
     self.frame = CGRectMake(0.0, 0.0, CGRectGetWidth(superviewBounds), CGRectGetHeight(superviewBounds));
     
-    void(^fadeInBlock)(void) = ^{_contentView.alpha = 1.0;};
+    __weak typeof(self) weakSelf = self;
+    void(^fadeInBlock)(void) = ^{weakSelf.contentView.alpha = 1.0;};
     
     if (self.fadeInOnDisplay) {
         [UIView animateWithDuration:0.25
@@ -1073,3 +1074,4 @@ Class dzn_baseClassToSwizzleForTarget(id target)
 }
 
 @end
+


### PR DESCRIPTION
Instead of using `_contentView` inside a block. 
Created a weak reference to self to use weakSelf instead of using `_contentView.` or `self.contentView` now uses `__weak.contentView`.