### PR TITLE
fix: Fix Xcode self retain cycle warning

### DIFF
--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -738,7 +738,7 @@ Class dzn_baseClassToSwizzleForTarget(id target)
     CGRect superviewBounds = self.superview.bounds;
     self.frame = CGRectMake(0.0, 0.0, CGRectGetWidth(superviewBounds), CGRectGetHeight(superviewBounds));
     
-    void(^fadeInBlock)(void) = ^{_contentView.alpha = 1.0;};
+    void(^fadeInBlock)(void) = ^{self->_contentView.alpha = 1.0;};
     
     if (self.fadeInOnDisplay) {
         [UIView animateWithDuration:0.25


### PR DESCRIPTION
Fix Xcode **Block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior** warning