### PR TITLE
Adds more styling control over the empty data set button

### DIFF
--- a/Source/UIScrollView+EmptyDataSet.h
+++ b/Source/UIScrollView+EmptyDataSet.h
@@ -91,6 +91,18 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable CAAnimation *)imageAnimationForEmptyDataSet:(UIScrollView *)scrollView;
 
 /**
+ Provides the data source with the means to customize the button that appears
+ at the bottom of the empty data set. Implementing this method will mean that
+ any values provided in `-buttonTitleForEmptyDataSet:forState:`,
+ `-buttonImageForEmptyDataSet:forState:`, and ``buttonBackgroundImageForEmptyDataSet:forState:`
+ will be ignored.
+
+ @param scrollView A scrollView subclass object informing the data source.
+ @param button The button that will be displayed at the bottom of the empty data set.
+ */
+- (void)emptyDataSet:(UIScrollView*)scrollView configureButton:(UIButton*)button;
+
+/**
  Asks the data source for the title to be used for the specified button state.
  The dataset uses a fixed font style by default, if no attributes are set. If you want a different font style, return a attributed string.
  

--- a/Source/UIScrollView+EmptyDataSet.m
+++ b/Source/UIScrollView+EmptyDataSet.m
@@ -505,9 +505,12 @@ static char const * const kEmptyDataSetView =       "emptyDataSetView";
             if (detailLabelString) {
                 view.detailLabel.attributedText = detailLabelString;
             }
-            
+
             // Configure button
-            if (buttonImage) {
+            if (self.emptyDataSetSource && [self.emptyDataSetSource respondsToSelector:@selector(emptyDataSet:configureButton:)]) {
+                [self.emptyDataSetSource emptyDataSet:self configureButton:view.button];
+            }
+            else if (buttonImage) {
                 [view.button setImage:buttonImage forState:UIControlStateNormal];
                 [view.button setImage:[self dzn_buttonImageForState:UIControlStateHighlighted] forState:UIControlStateHighlighted];
             }


### PR DESCRIPTION
Instead of being limited to customizing your button with a background image, plus either an image or title, this change optionally provides implementers with the opportunity to fully customize the empty data set button.